### PR TITLE
Add commands for converting to JS array and SQL-style "set"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to the "quotify" extension will be documented in this file.
 
+## [0.0.3]
+- Added simple command to convert a group of lines to a JS style array / SQL style set
+
 ## [0.0.2]
 - Changes to package only no code changes
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "activationEvents": [
         "onCommand:extension.quotifyQuoteStrings",
         "onCommand:extension.quotifyUnquoteStrings",
-        "onCommand:extension.quotifyNewlineStrings"
+        "onCommand:extension.quotifyNewlineStrings",
+        "onCommand:extension.buildArrayString",
+        "onCommand:extension.buildSqlSetString"
     ],
     "main": "./out/src/extension",
     "contributes": {
@@ -30,6 +32,14 @@
             {
                 "command": "extension.quotifyNewlineStrings",
                 "title": "Newline Delimit Strings"
+            },
+            {
+                "command": "extension.buildArrayString",
+                "title": "Convert to JS Array"
+            },
+            {
+                "command": "extension.buildSqlSetString",
+                "title": "Convert to SQL Set"
             }
         ]
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,17 +4,55 @@ import * as vscode from 'vscode';
 export function activate(context: vscode.ExtensionContext) {
 
     let quote = vscode.commands.registerCommand('extension.quotifyQuoteStrings', () => quoteStrings());
-
     let unquote = vscode.commands.registerCommand('extension.quotifyUnquoteStrings', () => unquoteStrings());
-
     let newline = vscode.commands.registerCommand('extension.quotifyNewlineStrings', () => newLineStrings());
+    let arrayString = vscode.commands.registerCommand('extension.buildArrayString', () => buildArrayString());
+    let sqlSetString = vscode.commands.registerCommand('extension.buildSqlSetString', () => buildSqlSetString());
 
     context.subscriptions.push(quote);
     context.subscriptions.push(unquote);
     context.subscriptions.push(newline);
+    context.subscriptions.push(arrayString);
+    context.subscriptions.push(sqlSetString);
 }
 
 export function deactivate() {
+}
+
+function buildArrayString() {
+    let editor = vscode.window.activeTextEditor;
+    let range;
+    if (!editor.selection.isEmpty) {
+        range = editor.selection;
+    } else {
+        vscode.window.showErrorMessage("No text selected");
+        return;
+    }
+
+    let text = editor.document.getText(range);
+    let result = JSON.stringify(splitByCommaOrNewLine(text));
+    editor.edit((builder) => {
+        builder.replace(range, result);
+    });
+    editor.revealRange(range);
+}
+
+function buildSqlSetString() {
+    let editor = vscode.window.activeTextEditor;
+    let range;
+    if (!editor.selection.isEmpty) {
+        range = editor.selection;
+    } else {
+        vscode.window.showErrorMessage("No text selected");
+        return;
+    }
+
+    let text = editor.document.getText(range);
+    let result = '(' + arrayToSqlSetString(splitByCommaOrNewLine(text)) + ')';
+    editor.edit((builder) => {
+        builder.replace(range, result);
+    });
+    editor.revealRange(range);
 }
 
 function quoteStrings () {
@@ -71,12 +109,35 @@ function newLineStrings () {
     editor.revealRange(range);
 }
 
+/**
+ * Split by commas (with leading/trailing spaces or tabs)
+ * or by newlines (with optional carriage return)
+ * 
+ * @param text the string to split
+ */
 export function splitByCommaOrNewLine (text: string): Array<string> {
     if(text.includes(',')){
-        return text.split(",")
+        return text.split(/[ \t]*,[ \t]*/)
     }else {
-        return text.split('\n');
+        return text.split(/\r?\n/);
     }
+}
+
+/**
+ * Ghetto escape and single quote array of strings
+ * @param strings array of strings to convert
+ */
+export function arrayToSqlSetString(strings: Array<string>): string {
+    return strings.filter((el) => {
+        return el.trim() !== ""
+    })
+        .map((str, idx, arr) => {
+            let last = arr.length - 1;
+            return idx === last ? `'${str.trim().replace('\'', '\'\'')}'` : `'${str.trim().replace('\'', '\'\'')}',`;
+        }).reverse()
+        .reduce((curr, prev): string => {
+            return prev += `${curr}`;
+        }, "");
 }
 
 export function arrayToQuotedString (strings: Array<string>) : string {


### PR DESCRIPTION
I found myself frequently using this plugin to convert \n delimited strings to JavaScript arrays so I modified your plugin to do the rest of the work for me.